### PR TITLE
Use HardwareSerial instead of SoftwareSerial in CAN-monitor example

### DIFF
--- a/examples/canbus-monitor/can-serial.h
+++ b/examples/canbus-monitor/can-serial.h
@@ -17,32 +17,11 @@
 
 #include "mcp_can.h"
 
-
 #define LOGGING_ENABLED
-
-#ifdef LOGGING_ENABLED
-#include "SoftwareSerial.h"
-#define dbg_begin(x) debug.begin(x)
-#define dbg0(x)   debug.print(x)
-#define dbg1(x)   debug.println(x)
-#define dbg2(x,y) debug.print(x); debug.println(y)
-#define dbgH(x)   debug.print(x,HEX)
-#define DEBUG_RX_PIN 8
-#define DEBUG_TX_PIN 9
-#else
-#define dbg_begin(x)
-#define dbg0(x) 
-#define dbg1(x) 
-#define dbg2(x,y)
-#define dbgH(x)
-#endif
-
-
 
 #define LWUART_LAWICEL_VERSION_STR     "V1013"
 #define LWUART_LAWICEL_SERIAL_NUM      "NA123"
 #define LWUART_CAN_BUS_SHIELD_CS_PIN   10
-
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -92,7 +71,7 @@
 #define HIGH_WORD(x)    ((unsigned short)(((x)>>16)&0xFFFF))
 
 #ifndef INT32U
-#define INT32U unsigned long
+  #define INT32U unsigned long
 #endif
 
 #ifndef INT16U

--- a/examples/canbus-monitor/canbus-monitor.ino
+++ b/examples/canbus-monitor/canbus-monitor.ino
@@ -15,20 +15,21 @@
 #include "mcp_can.h"
 #include "can-serial.h"
 
+//#define CAN_2518FD
 #define CAN_2515
 
 #ifdef CAN_2518FD
-#include "mcp2518fd_can.h"
-const int SPI_CS_PIN = BCM8;
-const int CAN_INT_PIN = BCM25;
-mcp2518fd CAN(SPI_CS_PIN); // Set CS pin
+  #include "mcp2518fd_can.h"
+  const int SPI_CS_PIN = BCM8;
+  const int CAN_INT_PIN = BCM25;
+  mcp2518fd CAN(SPI_CS_PIN); // Set CS pin
 #endif
 
 #ifdef CAN_2515
-#include "mcp2515_can.h"
-const int SPI_CS_PIN = 9;
-const int CAN_INT_PIN = 2;
-mcp2515_can CAN(SPI_CS_PIN); // Set CS pin
+  #include "mcp2515_can.h"
+  const int SPI_CS_PIN = 9;
+  const int CAN_INT_PIN = 2;
+  mcp2515_can CAN(SPI_CS_PIN); // Set CS pin
 #endif                              // Set CS pin
 
 
@@ -83,4 +84,3 @@ void loop() {
 void serialEvent() {
     CanSerial::serialEvent();
 }
-


### PR DESCRIPTION
I created this to help resolve #105 

I do not have an Arduino DUE to test but this does build successfully. Someone with an Arduino DUE will need to verify this actually works. 