### PR TITLE
Removed unused include statement

### DIFF
--- a/src/can-serial.cpp
+++ b/src/can-serial.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #ifdef LOGGING_ENABLED
+	#include "SoftwareSerial.h"
     // software serial #2: TX = digital pin 8, RX = digital pin 9
     // on the Mega, use other pins instead, since 8 and 9 don't work on the Mega
     SoftwareSerial debug(DEBUG_RX_PIN, DEBUG_TX_PIN);

--- a/src/can-serial.h
+++ b/src/can-serial.h
@@ -22,7 +22,6 @@
 //#endif
 
 #include "mcp_can.h"
-#include "SoftwareSerial.h"
 
 
 #define LW232_LAWICEL_VERSION_STR     "V1013"


### PR DESCRIPTION
Including the SoftwareSerial.h library makes this repo incompatible with the Particle series of MCUs. This library doesn't appear to be used anywhere in this repo. Removing it would improve compatibility with more MCUs. 