### PR TITLE
Removed special character and updated keywords.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CAN_BUS_Shield",
-  "keywords": "can, bus, MCP2518FD ，mcp2515, MCP-2515",
+  "keywords": "can, bus, mcp2518fd, mcp2515, mcp-2515",
   "description": "Seeed Arduino library to control  CAN-BUS and CAN BUS FD.",
   "repository":
   {


### PR DESCRIPTION
There was a special character comma after the `MCP2518FD` in the keywords section.  I also updated the keywords to lowercase per the PlatformIO manifest guidelines for [keywords](https://docs.platformio.org/en/latest/librarymanager/config.html#keywords).  These changes did allow the library to package for PlatformIO.  Let me know if you like me to package master as 2.3.0 for PlatformIO or if you would rather do a 2.3.1 release with these changes.  Sorry for all the little nit picky stuff.