### PR TITLE
Fix Arduino Uno Wifi Rev2 and Arduino Nano Every Compatibility

### DIFF
--- a/src/mcp2518fd_can.cpp
+++ b/src/mcp2518fd_can.cpp
@@ -1909,15 +1909,15 @@ byte mcp2518fd::init_Mask(byte num, byte ext, unsigned long ulData) {
   mcp2518fd_OperationModeSelect(CAN_CONFIGURATION_MODE);
 
   mcp2518fd_FilterToFifoLink((CAN_FILTER)num, APP_RX_FIFO, false);
-  
+
   // Setup RX Mask
   mObj.word = 0;
   mObj.bF.MSID = ulData;
   mObj.bF.MIDE = ext;
   err = mcp2518fd_FilterMaskConfigure((CAN_FILTER)num, &mObj.bF);
-  
+
   mcp2518fd_FilterToFifoLink((CAN_FILTER)num, APP_RX_FIFO, true);
-  
+
   mcp2518fd_OperationModeSelect(mcpMode);
 
   return err;
@@ -1932,7 +1932,7 @@ byte mcp2518fd::init_Filt(byte num, byte ext, unsigned long ulData) {
   err = mcp2518fd_OperationModeSelect(CAN_CONFIGURATION_MODE);
 
   mcp2518fd_FilterToFifoLink((CAN_FILTER)num, APP_RX_FIFO, false);
-  
+
   // Setup RX Filter
   fObj.word = 0;
   if (!ext) {            // standard identifier
@@ -1942,9 +1942,9 @@ byte mcp2518fd::init_Filt(byte num, byte ext, unsigned long ulData) {
   }
   fObj.bF.EXIDE = !!ext;
   mcp2518fd_FilterObjectConfigure((CAN_FILTER)num, &fObj.bF);
-  
+
   mcp2518fd_FilterToFifoLink((CAN_FILTER)num, APP_RX_FIFO, true);
-  
+
   mcp2518fd_OperationModeSelect(mcpMode);
   return err;
 }
@@ -2252,10 +2252,10 @@ byte mcp2518fd::mcpDigitalRead(const byte pin) {
   // Update data
   switch (pin) {
   case GPIO_PIN_0:
-    state = (GPIO_PIN_STATE)iocon.bF.GPIO0;
+    state = (GPIO_PIN_STATE)iocon.bF.GPIO0_;
     break;
   case GPIO_PIN_1:
-    state = (GPIO_PIN_STATE)iocon.bF.GPIO1;
+    state = (GPIO_PIN_STATE)iocon.bF.GPIO1_;
     break;
   default:
     return -1;

--- a/src/mcp2518fd_can_dfs.h
+++ b/src/mcp2518fd_can_dfs.h
@@ -1463,8 +1463,8 @@ typedef union _REG_IOCON {
     uint32_t LAT1 : 1;
     uint32_t unimplemented3 : 5;
     uint32_t HVDETSEL : 1;
-    uint32_t GPIO0 : 1;
-    uint32_t GPIO1 : 1;
+    uint32_t GPIO0_ : 1;
+    uint32_t GPIO1_ : 1;
     uint32_t unimplemented4 : 6;
     uint32_t PinMode0 : 1;
     uint32_t PinMode1 : 1;


### PR DESCRIPTION
When compiling this library for the Arduino Uno Wifi Rev 2 I found there was a build error with the following output. Using Arduino 1.8.15 for 64-bit Linux
```
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can_dfs.h:1466:14: error: expected unqualified-id before 'volatile'
     uint32_t GPIO0 : 1;
              ^
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can_dfs.h:1466:14: error: expected ')' before 'volatile'
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can_dfs.h:1466:14: error: expected ')' before 'volatile'
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can_dfs.h:1467:14: error: expected unqualified-id before 'volatile'
     uint32_t GPIO1 : 1;
              ^
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can_dfs.h:1467:14: error: expected ')' before 'volatile'
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can_dfs.h:1467:14: error: expected ')' before 'volatile'
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can.cpp: In member function 'virtual byte mcp2518fd::mcpDigitalRead(byte)':
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can.cpp:2255:38: error: expected unqualified-id before '(' token
     state = (GPIO_PIN_STATE)iocon.bF.GPIO0;
                                      ^
/home/qt/Arduino/libraries/Seeed_Arduino_CAN/src/mcp2518fd_can.cpp:2258:38: error: expected unqualified-id before '(' token
     state = (GPIO_PIN_STATE)iocon.bF.GPIO1;
```

It looks like this is caused by a board-specific macro that is redefining `GPIO0` and `GPIO1`. I did not go through the Arduino source to find the root of the issue, but renaming the two variables to `GPIO0_` and `GPIO1_` solved the issue.

The Arduino Nano Every uses the same chipset and is affected by the same issue