### PR TITLE
Move the four-argument sendMsgBuf wrapper to mcp_can.h

### DIFF
--- a/src/mcp2515_can.h
+++ b/src/mcp2515_can.h
@@ -92,10 +92,7 @@ public:
     virtual byte trySendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, byte iTxBuf = 0xff);                                 // as sendMsgBuf, but does not have any wait for free buffer
     virtual byte sendMsgBuf(byte status, unsigned long id, byte ext, byte rtrBit, byte len, volatile const byte *buf);                                  // send message buf by using parsed buffer status
     virtual byte sendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, bool wait_sent = true);                                 // send buf
-    /* wrapper */
-    inline byte sendMsgBuf(unsigned long id, byte ext, byte len, const byte *buf) {
-        return sendMsgBuf(id, ext, 0, len, buf, true);
-    }
+
 
     virtual void clearBufferTransmitIfFlags(byte flags = 0);                                                                                            // Clear transmit flags according to status
     virtual byte readRxTxStatus(void);                                                                                                                  // read has something send or received

--- a/src/mcp2518fd_can.h
+++ b/src/mcp2518fd_can.h
@@ -154,10 +154,7 @@ public:
                           byte dlc, volatile const byte *buf);
   virtual byte sendMsgBuf(unsigned long id, byte ext, byte rtr, byte dlc,
                           const byte *buf, bool wait_sent = true);
-  /* wrapper */
-  inline byte sendMsgBuf(unsigned long id, byte ext, byte len, const byte *buf) {
-    return sendMsgBuf(id, ext, 0, len, buf, true);
-  }
+
 
   virtual void clearBufferTransmitIfFlags(byte flags = 0);
   virtual byte readRxTxStatus(void);

--- a/src/mcp_can.h
+++ b/src/mcp_can.h
@@ -94,7 +94,11 @@ public:
                                byte len, volatile const byte *buf) = 0;                 // send message buf by using parsed buffer status
     virtual byte sendMsgBuf(unsigned long id, byte ext, byte rtrBit,
                                byte len, const byte *buf, bool wait_sent = true) = 0;   // send message with wait
-
+    /* wrapper */
+    inline byte sendMsgBuf(unsigned long id, byte ext, byte len, const byte *buf) {
+        return sendMsgBuf(id, ext, 0, len, buf, true);
+    }
+    
     virtual void clearBufferTransmitIfFlags(byte flags = 0) = 0;                        // Clear transmit flags according to status
     virtual byte readRxTxStatus(void) = 0;                                              // read has something send or received
     virtual byte checkClearRxStatus(byte *status) = 0;                                  // read and clear and return first found rx status bit


### PR DESCRIPTION
Right now, the abstract MCP_CAN class doesn't support the four-argument wrapper for sendMsgBuf. But its definition and implementation is copied and pasted in every implemented subclass in this repo. 

This pull request will move that wrapper to the MCP_CAN class, reducing redundancy.