### PR TITLE
Reset rx overflow flag

### DIFF
--- a/src/mcp2515_can.cpp
+++ b/src/mcp2515_can.cpp
@@ -1396,6 +1396,7 @@ byte mcp2515_can::checkReceive(void) {
 *********************************************************************************************************/
 byte mcp2515_can::checkError(uint8_t* err_ptr) {
     byte eflg = mcp2515_readRegister(MCP_EFLG);
+    mcp2515_modifyRegister(MCP_EFLG, 0xFF, 0);
     if (err_ptr) {
         *err_ptr = eflg;
     }


### PR DESCRIPTION
In the method mcp2515_can::checkError(), register EFLG is not reset after tx buffer overflow occurring. I put the code to reset it, so that it will not be error again and again without cause.