### PR TITLE
Patch four-argument sendmsgbuf

### DIFF
--- a/examples/OBDII_PIDs/OBDII_PIDs.ino
+++ b/examples/OBDII_PIDs/OBDII_PIDs.ino
@@ -80,7 +80,7 @@ void sendPid(unsigned char __pid) {
     unsigned char tmp[8] = {0x02, 0x01, __pid, 0, 0, 0, 0, 0};
     SERIAL_PORT_MONITOR.print("SEND PID: 0x");
     SERIAL_PORT_MONITOR.println(__pid, HEX);
-    CAN.MCP_CAN::sendMsgBuf(CAN_ID_PID, 0, 8, tmp);
+    CAN.sendMsgBuf(CAN_ID_PID, 0, 8, tmp);
 }
 
 void setup() {

--- a/examples/send/send.ino
+++ b/examples/send/send.ino
@@ -4,8 +4,8 @@
 
 #include <SPI.h>
 
-#define CAN_2515
-// #define CAN_2518FD
+//#define CAN_2515
+#define CAN_2518FD
 
 // Set SPI CS Pin according to your hardware
 
@@ -61,7 +61,7 @@ void loop() {
         }
     }
 
-    CAN.MCP_CAN::sendMsgBuf(0x00, 0, 8, stmp);
+    CAN.sendMsgBuf(0x00, 0, 8, stmp);
     delay(100);                       // send data per 100ms
     SERIAL_PORT_MONITOR.println("CAN BUS sendMsgBuf ok!");
 }

--- a/examples/sendFD/sendFD.ino
+++ b/examples/sendFD/sendFD.ino
@@ -54,7 +54,7 @@ void loop() {
         }
     }
 
-    CAN.MCP_CAN::sendMsgBuf(0x00, 0, CANFD::len2dlc(MAX_DATA_SIZE), stmp);
+    CAN.sendMsgBuf(0x00, 0, CANFD::len2dlc(MAX_DATA_SIZE), stmp);
     delay(100);                       // send data per 100ms
     SERIAL_PORT_MONITOR.println("CAN BUS sendMsgBuf ok!");
 }

--- a/examples/send_Blink/send_Blink.ino
+++ b/examples/send_Blink/send_Blink.ino
@@ -1,8 +1,8 @@
 // demo: CAN-BUS Shield, send data
 #include <SPI.h>
 
-#define CAN_2515
-// #define CAN_2518FD
+//#define CAN_2515
+#define CAN_2518FD
 
 // Set SPI CS Pin according to your hardware
 
@@ -52,7 +52,7 @@ unsigned char stmp[8] = {ledHIGH, 1, 2, 3, ledLOW, 5, 6, 7};
 void loop() {
     SERIAL_PORT_MONITOR.println("In loop");
     // send data:  id = 0x70, standard frame, data len = 8, stmp: data buf
-    CAN.MCP_CAN::sendMsgBuf(0x70, 0, 8, stmp);
+    CAN.sendMsgBuf(0x70, 0, 8, stmp);
     delay(1000);                       // send data once per second
 }
 

--- a/examples/send_Blink_ROS/send_Blink_ROS.ino
+++ b/examples/send_Blink_ROS/send_Blink_ROS.ino
@@ -26,7 +26,7 @@ mcp2515_can CAN(SPI_CS_PIN); // Set CS pin
 void messageCb(const std_msgs::Empty& toggle_msg) {
     //digitalWrite(13, HIGH-digitalRead(13));   // blink the led
     // send data:  id = 0x00, standrad frame, data len = 8, stmp: data buf
-    CAN.MCP_CAN::sendMsgBuf(0x70, 0, 8, stmp);
+    CAN.sendMsgBuf(0x70, 0, 8, stmp);
     delay(1000);                       // send data per 100ms
 }
 

--- a/examples/send_sleep/send_sleep.ino
+++ b/examples/send_sleep/send_sleep.ino
@@ -83,7 +83,7 @@ unsigned char stmp[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 void loop() {
     SERIAL_PORT_MONITOR.println("Sending message");
 
-    CAN.MCP_CAN::sendMsgBuf(0x00, 0, 0, NULL);     // Send empty wakeup message
+    CAN.sendMsgBuf(0x00, 0, 0, NULL);     // Send empty wakeup message
 
     delay(100);                           // give the receiving node some time to wake up
 
@@ -100,7 +100,7 @@ void loop() {
         }
     }
 
-    CAN.MCP_CAN::sendMsgBuf(0x00, 0, 8, stmp);
+    CAN.sendMsgBuf(0x00, 0, 8, stmp);
 
 
     // sleep

--- a/examples/set_mask_filter_send/set_mask_filter_send.ino
+++ b/examples/set_mask_filter_send/set_mask_filter_send.ino
@@ -51,7 +51,7 @@ unsigned char stmp[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 void loop() {
     for (int id = 0; id < 10; id++) {
         memset(stmp, id, sizeof(stmp));                 // set id to send data buff
-        CAN.MCP_CAN::sendMsgBuf(id, 0, sizeof(stmp), stmp);
+        CAN.sendMsgBuf(id, 0, sizeof(stmp), stmp);
         delay(100);
     }
 }

--- a/src/can-serial.h
+++ b/src/can-serial.h
@@ -211,7 +211,7 @@ private:
     INT8U openCanBus();
     
     INT8U sendMsgBuf(INT32U id, INT8U ext, INT8U rtr, INT8U len, INT8U *buf);
-
+    
     void  parseCanStdId();
     void  parseCanExtId();
 };

--- a/src/mcp2515_can.h
+++ b/src/mcp2515_can.h
@@ -92,7 +92,7 @@ public:
     virtual byte trySendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, byte iTxBuf = 0xff);                                 // as sendMsgBuf, but does not have any wait for free buffer
     virtual byte sendMsgBuf(byte status, unsigned long id, byte ext, byte rtrBit, byte len, volatile const byte *buf);                                  // send message buf by using parsed buffer status
     virtual byte sendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, bool wait_sent = true);                                 // send buf
-
+    using MCP_CAN::sendMsgBuf; // make other overloads visible
 
     virtual void clearBufferTransmitIfFlags(byte flags = 0);                                                                                            // Clear transmit flags according to status
     virtual byte readRxTxStatus(void);                                                                                                                  // read has something send or received

--- a/src/mcp2518fd_can.h
+++ b/src/mcp2518fd_can.h
@@ -154,6 +154,7 @@ public:
                           byte dlc, volatile const byte *buf);
   virtual byte sendMsgBuf(unsigned long id, byte ext, byte rtr, byte dlc,
                           const byte *buf, bool wait_sent = true);
+  using MCP_CAN::sendMsgBuf; // make other overloads visible
 
 
   virtual void clearBufferTransmitIfFlags(byte flags = 0);


### PR DESCRIPTION
Maintains backward compatibility with previous versions of the function call by making MCP_CAN::sendMsgBuf visible from the derived classes `mcp2518fd` and `mcp2515`

Now it is possible to compile one or both of the following:
```cpp
CAN.MCP_CAN::sendMsgBuf(0x70, 0, 8, stmp);
CAN.sendMsgBuf(0x70, 0, 8, stmp);
```

Tested by  successfully compiling `send` and `send_Blink` for the Arduino Uno with the `CAN_2518FD` or `CAN_2515` flag enabled